### PR TITLE
Allow skipping of the JSON parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG.md
 
+## v1.1.0
+
+- [Allow skipping of the JSON parsing](https://github.com/babbel/terraform-aws-sns-to-rollbar/pull/4)
+
 ## v1.0.0
 
 - [Initial version](https://github.com/babbel/terraform-aws-sns-to-rollbar/pull/1)

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -2,12 +2,30 @@ provider "aws" {
   region = "local"
 }
 
-module "sns-to-rollbar" {
+module "sns-to-rollbar-with-json-key" {
   source = "./.."
 
   name = "example"
 
   json_key = "message"
+
+  rollbar_project_access_token = {
+    access_token = "some-token"
+  }
+
+  environment = "test"
+  level       = "debug"
+
+  tags = {
+    app = "some-service"
+    env = "test"
+  }
+}
+
+module "sns-to-rollbar-without-json-key" {
+  source = "./.."
+
+  name = "example"
 
   rollbar_project_access_token = {
     access_token = "some-token"

--- a/variables.tf
+++ b/variables.tf
@@ -7,10 +7,12 @@ EOS
 }
 
 variable "json_key" {
-  type = string
+  type    = string
+  default = "-"
 
   description = <<EOS
 If the message is JSON, this is the key to use to extract the message used as Rollbar item title.
+If the value is "-", the implementation will not attempt to parse the message as JSON.
 EOS
 }
 


### PR DESCRIPTION
... even if the payload is JSON. That's useful for events sent by ElastiCache to SNS, as the JSON payload does not have well-defined JSON keys, but the JSON keys are actually part of the payload.

Please review by ignoring whitespaces.

Replacement for https://github.com/babbel/terraform-aws-sns-to-rollbar/pull/2