### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# NOTE: CHANGELOG.md is deprecated
+
+After the release of v1.1.0, please see the [GitHub release notes](https://github.com/babbel/terraform-aws-sns-to-rollbar/releases)
+for the module in order to view the most up-to-date changes.
+
 # CHANGELOG.md
 
 ## v1.1.0

--- a/README.md
+++ b/README.md
@@ -19,10 +19,5 @@ module "sns-to-rollbar" {
 
   environment = "test"
   level      = "debug"
-
-  tags = {
-    app = "some-service"
-    env = "test"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -16,7 +16,7 @@ module "sns-to-rollbar-with-json-key" {
   environment = "test"
   level       = "debug"
 
-  tags = {
+  default_tags = {
     app = "some-service"
     env = "test"
   }
@@ -34,7 +34,7 @@ module "sns-to-rollbar-without-json-key" {
   environment = "test"
   level       = "debug"
 
-  tags = {
+  default_tags = {
     app = "some-service"
     env = "test"
   }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 
 resource "aws_sns_topic" "this" {
   name = var.name
-  tags = var.tags
+  tags = merge(var.default_tags, var.sns_topic_tags)
 }
 
 resource "aws_sns_topic_subscription" "sqs-queue" {
@@ -15,7 +15,7 @@ resource "aws_sns_topic_subscription" "sqs-queue" {
 
 resource "aws_sqs_queue" "this" {
   name = var.name
-  tags = var.tags
+  tags = merge(var.default_tags, var.sqs_queue_tags)
 }
 
 data "aws_iam_policy_document" "sqs-queue-consume" {
@@ -73,7 +73,7 @@ resource "aws_pipes_pipe" "this" {
     }
   }
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.pipes_pipe_tags)
 
   depends_on = [
     aws_iam_role_policy.pipes-pipe-sqs-queue-consume,
@@ -84,7 +84,8 @@ resource "aws_pipes_pipe" "this" {
 resource "aws_iam_role" "pipes-pipe" {
   name               = "pipes-${var.name}"
   assume_role_policy = data.aws_iam_policy_document.pipes-assume-role.json
-  tags               = var.tags
+
+  tags = merge(var.default_tags, var.pipes_pipe_iam_role_tags)
 }
 
 data "aws_iam_policy_document" "pipes-assume-role" {
@@ -284,7 +285,7 @@ resource "aws_sfn_state_machine" "this" {
     })
   )
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.sfn_state_machine_tags)
 }
 
 data "aws_iam_policy_document" "sfn-state-machine-start-execution" {
@@ -297,7 +298,8 @@ data "aws_iam_policy_document" "sfn-state-machine-start-execution" {
 resource "aws_iam_role" "sfn-state-machine" {
   name               = "step-function-${var.name}"
   assume_role_policy = data.aws_iam_policy_document.states.json
-  tags               = var.tags
+
+  tags = merge(var.default_tags, var.sfn_state_machine_iam_role_tags)
 }
 
 data "aws_iam_policy_document" "states" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "environment" {
   type = string
 
@@ -12,6 +21,7 @@ variable "json_key" {
 
   description = <<EOS
 If the message is JSON, this is the key to use to extract the message used as Rollbar item title.
+
 If the value is "-", the implementation will not attempt to parse the message as JSON.
 EOS
 }
@@ -32,6 +42,24 @@ The name used in all related AWS resources.
 EOS
 }
 
+variable "pipes_pipe_iam_role_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the IAM role used by the Step Function.
+EOS
+}
+
+variable "pipes_pipe_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the EventBridge Pipe.
+EOS
+}
+
 variable "rollbar_project_access_token" {
   type = object({
     access_token = string
@@ -42,11 +70,38 @@ The Rollbar project access token used to post items to Rollbar. It must the `pos
 EOS
 }
 
-variable "tags" {
+variable "sfn_state_machine_iam_role_tags" {
   type    = map(string)
   default = {}
 
   description = <<EOS
-Tags to apply to all AWS resources.
+Map of tags assigned to the IAM role used by the Step Function.
+EOS
+}
+
+variable "sfn_state_machine_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the Step Function.
+EOS
+}
+
+variable "sns_topic_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the SNS topic.
+EOS
+}
+
+variable "sqs_queue_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the SQS queue.
 EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.