### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,5 @@ module "sns-to-rollbar" {
 
   environment = "test"
   level      = "debug"
-
-  tags = {
-    app = "some-service"
-    env = "test"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -16,7 +16,7 @@ module "sns-to-rollbar-with-json-key" {
   environment = "test"
   level       = "debug"
 
-  tags = {
+  default_tags = {
     app = "some-service"
     env = "test"
   }
@@ -34,7 +34,7 @@ module "sns-to-rollbar-without-json-key" {
   environment = "test"
   level       = "debug"
 
-  tags = {
+  default_tags = {
     app = "some-service"
     env = "test"
   }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 
 resource "aws_sns_topic" "this" {
   name = var.name
-  tags = var.tags
+  tags = var.default_tags
 }
 
 resource "aws_sns_topic_subscription" "sqs-queue" {
@@ -15,7 +15,7 @@ resource "aws_sns_topic_subscription" "sqs-queue" {
 
 resource "aws_sqs_queue" "this" {
   name = var.name
-  tags = var.tags
+  tags = var.default_tags
 }
 
 data "aws_iam_policy_document" "sqs-queue-consume" {
@@ -73,7 +73,7 @@ resource "aws_pipes_pipe" "this" {
     }
   }
 
-  tags = var.tags
+  tags = var.default_tags
 
   depends_on = [
     aws_iam_role_policy.pipes-pipe-sqs-queue-consume,
@@ -84,7 +84,7 @@ resource "aws_pipes_pipe" "this" {
 resource "aws_iam_role" "pipes-pipe" {
   name               = "pipes-${var.name}"
   assume_role_policy = data.aws_iam_policy_document.pipes-assume-role.json
-  tags               = var.tags
+  tags               = var.default_tags
 }
 
 data "aws_iam_policy_document" "pipes-assume-role" {
@@ -284,7 +284,7 @@ resource "aws_sfn_state_machine" "this" {
     })
   )
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 data "aws_iam_policy_document" "sfn-state-machine-start-execution" {
@@ -297,7 +297,7 @@ data "aws_iam_policy_document" "sfn-state-machine-start-execution" {
 resource "aws_iam_role" "sfn-state-machine" {
   name               = "step-function-${var.name}"
   assume_role_policy = data.aws_iam_policy_document.states.json
-  tags               = var.tags
+  tags               = var.default_tags
 }
 
 data "aws_iam_policy_document" "states" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "environment" {
   type = string
 
@@ -39,14 +48,5 @@ variable "rollbar_project_access_token" {
 
   description = <<EOS
 The Rollbar project access token used to post items to Rollbar. It must the `post_server_item` scope.
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.