### PR TITLE
Check formatting, make suggestions in PRs

### DIFF
--- a/.github/workflows/tf-commenter.yml
+++ b/.github/workflows/tf-commenter.yml
@@ -1,0 +1,20 @@
+name: Post comments about TF syntax
+
+on: pull_request
+
+jobs:
+  post-format-comment:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+      - name: Terraform Format
+        run: terraform fmt -recursive
+      - name: Suggest format changes
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: terraform fmt
+          level: error

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ matrix.terraform_version }}
+      - run: terraform fmt -diff -check -recursive
       - run: terraform init
       - run: terraform validate
 


### PR DESCRIPTION
# Rationale

Instead of just failing the build, an action makes suggestions based on the output of `terraform fmt`.

> [!NOTE]
> Adding a workflow is cleaner IMO because it's run on a different trigger (`pull_request`), but both workflows run `terraform fmt` because `validate` fails the build.
